### PR TITLE
Fix settings storage and persistent UI

### DIFF
--- a/js/backend/SettingsManager.js
+++ b/js/backend/SettingsManager.js
@@ -44,9 +44,44 @@ export class SettingsManager {
         this.settings = { ...DefaultExtensionOptions };
         this.unsavedChanges = false;
         this.storage = chrome?.storage?.sync || {
-            get: (keys, callback) => callback({}),
-            set: (items, callback) => callback(),
-            clear: (callback) => callback()
+            get: (keys, callback) => {
+                const result = {};
+                if (keys === null) {
+                    for (let i = 0; i < localStorage.length; i++) {
+                        const k = localStorage.key(i);
+                        try {
+                            result[k] = JSON.parse(localStorage.getItem(k));
+                        } catch {
+                            result[k] = localStorage.getItem(k);
+                        }
+                    }
+                } else if (Array.isArray(keys)) {
+                    keys.forEach(key => {
+                        try {
+                            result[key] = JSON.parse(localStorage.getItem(key));
+                        } catch {
+                            result[key] = localStorage.getItem(key);
+                        }
+                    });
+                } else if (typeof keys === 'string') {
+                    try {
+                        result[keys] = JSON.parse(localStorage.getItem(keys));
+                    } catch {
+                        result[keys] = localStorage.getItem(keys);
+                    }
+                }
+                callback(result);
+            },
+            set: (items, callback) => {
+                Object.entries(items).forEach(([key, value]) => {
+                    localStorage.setItem(key, JSON.stringify(value));
+                });
+                callback && callback();
+            },
+            clear: (callback) => {
+                localStorage.clear();
+                callback && callback();
+            }
         };
         this.listeners = new Set();
         this.initialized = false;

--- a/js/modules/engine/StockfishEngine.js
+++ b/js/modules/engine/StockfishEngine.js
@@ -192,6 +192,10 @@ export class StockfishEngine {
       return;
     }
 
+    if (this.BetterMintmaster.game) {
+      this.BetterMintmaster.game.clearArrows();
+    }
+
     if (FENs) {
       this.currentFEN = FENs;
     } else {
@@ -236,6 +240,9 @@ export class StockfishEngine {
     this.lastTopMoves = [];
     this.currentFEN = null;
     this.isAnalyzing = false;
+    if (this.BetterMintmaster.game) {
+      this.BetterMintmaster.game.clearArrows();
+    }
   }
 
   UpdateExtensionOptions(options) {
@@ -398,16 +405,8 @@ export class StockfishEngine {
     }
 
     // Add arrow with proper color
-    if (this.BetterMintmaster.game && this.BetterMintmaster.game.controller) {
-      const arrowMarking = {
-        type: 'arrow',
-        from: from,
-        to: to,
-        color: color,
-        data: { from, to, color: color }
-      };
-      
-      this.BetterMintmaster.game.controller.markings.addOne(arrowMarking);
+    if (this.BetterMintmaster.game) {
+      this.BetterMintmaster.game.addArrow(from, to, color);
     }
 
     // Store move for analysis

--- a/js/modules/ui/AnalysisTools.js
+++ b/js/modules/ui/AnalysisTools.js
@@ -12,10 +12,10 @@ export class AnalysisTools {
     this.evalScore = null;
     this.evalScoreAbbreviated = null;
     
-    // Get the board container
-    this.boardContainer = document.querySelector('.board-container') || 
+    // Use the board container if available, otherwise fallback to body
+    this.boardContainer = this.chessboard?.element ||
+                        document.querySelector('.board-container') ||
                         document.querySelector('.board') ||
-                        this.chessboard.element ||
                         document.body;
     
     // Initialize UI elements based on settings
@@ -28,6 +28,9 @@ export class AnalysisTools {
     
     // Set up event listeners
     this.setupEventListeners();
+
+    // Observe DOM changes to ensure bars remain attached
+    this.startDomObserver();
   }
 
   setupEventListeners() {
@@ -277,4 +280,18 @@ export class AnalysisTools {
       this.hideAnalysis();
     }
   }
-} 
+
+  startDomObserver() {
+    const observer = new MutationObserver(() => {
+      if (this.evalBar && !document.body.contains(this.evalBar)) {
+        document.body.appendChild(this.evalBar);
+      }
+      if (this.depthBar && !document.body.contains(this.depthBar)) {
+        document.body.appendChild(this.depthBar);
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+    this.domObserver = observer;
+  }
+}

--- a/js/modules/ui/GameController.js
+++ b/js/modules/ui/GameController.js
@@ -1,5 +1,6 @@
 import { enumOptions, getValueConfig } from '../core/Config.js';
 import { getGradientColor } from '../utils/ColorUtils.js';
+import { Arrows } from './Arrows.js';
 
 export class GameController {
   constructor(BetterMintmaster, chessboard) {
@@ -14,6 +15,7 @@ export class GameController {
     this.evalScoreAbbreviated = null;
     this.currentMarkings = [];
     this.accuracyDisplay = null;
+    this.arrows = new Arrows(chessboard);
     
     this.initializeEventListeners();
     this.initializeAnalysisTools();
@@ -147,4 +149,16 @@ export class GameController {
       this.evalScoreAbbreviated.textContent = score.toFixed(1);
     }
   }
-} 
+
+  addArrow(from, to, color) {
+    if (this.arrows) {
+      this.arrows.addArrow(from, to, color);
+    }
+  }
+
+  clearArrows() {
+    if (this.arrows) {
+      this.arrows.clearArrows();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make settings persist even when `chrome.storage` is unavailable by falling back to `localStorage`
- keep evaluation/depth bars in the DOM using a MutationObserver
- add Arrows manager to GameController and integrate with engine
- ensure arrows are cleared on new analysis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684072c8c8a88328ae213a2e60c3c7d1